### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # ArtisanPack UI Hooks Changelog
 
+## [1.3.0] - July 20, 2026
+
+### Added
+- `HookDeprecations` primitive for backwards-compatible hook renaming
+  - `deprecateHook(string $old, string $new): void` helper registers a rename in one line
+  - `Action` and `Filter` transparently route `add()`/`remove()`/`removeAll()` through the alias map
+  - `do()` / `apply()` fan out across canonical and alias buckets so pre-deprecation subscribers still fire
+  - Callbacks registered under both the old and canonical names are de-duplicated by identity within a single dispatch (closures, invokable objects, `[$obj, 'method']`, `[Class::class, 'staticMethod']`, and string function names all key correctly). Deliberate double-registrations within a single bucket still fire twice
+  - Stable insertion-order tie-break within a priority is preserved via a monotonic sequence counter, even when a callback is routed through an alias bucket
+  - Cycles are rejected: `deprecateHook('a', 'b')` followed by `deprecateHook('b', 'a')` throws `InvalidArgumentException` instead of silently creating a `b → b` self-alias
+  - Deprecation notices log only on dispatch (`do`/`apply`), never on `add`/`remove` — so the log entry is anchored to real hook use, not to boot-time registration
+  - Log gate reads from the published `config/artisanpack/hooks.php` (`deprecation_level` key), falling back to `HOOKS_DEPRECATION_LEVEL` env for zero-config use. Any PSR-3 level (`emergency`, `alert`, `critical`, `error`, `warning`, `notice`, `info`, `debug`) is accepted; `off` suppresses the log
+  - "Log once per unique alias" is scoped per request, not per process: the service provider resets the dedup on Octane `RequestReceived` and Queue `JobProcessing` so long-lived workers do not swallow every notice after the first request/job
+  - `HookDeprecations` is container-resolvable via `app(HookDeprecations::class)` — no new Facade or helper surface beyond `deprecateHook()`
+- Config file at `config/hooks.php`, publishable via `php artisan vendor:publish --tag=hooks-config`
+- `src/Concerns/ManagesHookBuckets.php` trait shared by `Action` and `Filter`, so bucket / alias / dedup / removal logic lives in one place instead of duplicated across both classes
+- README section documenting the naming convention and shared cross-package hooks (`ap.google.scopes`, `ap.icons.registerIconSets`)
+
 ## [1.2.1] - June 8, 2026
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This package lets you register callbacks on named hooks (actions) and filter val
 - Priorities and execution order
 - Using Facades
 - Blade directives
+- Hook naming and deprecations (since 1.3.0)
 - Testing locally
 - Contributing
 - Security
@@ -23,7 +24,7 @@ This package lets you register callbacks on named hooks (actions) and filter val
 
 ## Features
 - Simple API for registering and dispatching actions and filters
-- Helper functions: `addAction`, `doAction`, `removeAction` (since 1.1.0), `removeAllActions` (since 1.1.0), `addFilter`, `applyFilters`, `removeFilter` (since 1.1.0), `removeAllFilters` (since 1.1.0)
+- Helper functions: `addAction`, `doAction`, `removeAction` (since 1.1.0), `removeAllActions` (since 1.1.0), `addFilter`, `applyFilters`, `removeFilter` (since 1.1.0), `removeAllFilters` (since 1.1.0), `deprecateHook` (since 1.3.0)
 - Static Facades for Laravel: `Action` and `Filter`
 - Blade directives: `@action` and `@filter`
 - Runs callbacks in predictable priority order (lower numbers first)
@@ -155,6 +156,40 @@ You can trigger actions and apply filters directly within Blade views.
 
 - `@action('hook', $args...)` calls `doAction('hook', $args...)`.
 - `@filter('hook', $value, $args...)` echoes `applyFilters('hook', $value, $args...)`.
+
+## Hook naming and deprecations (since 1.3.0)
+
+Hook names should be namespaced with dot notation and lower camelCase segments — for example, `order.placed`, `user.registered`, `ap.icons.registerIconSets`. The `ap.<domain>.<event>` prefix is reserved for cross-package hooks that any ArtisanPack UI package (or downstream app) may listen to. Two of these are intentionally shared today:
+
+- `ap.google.scopes` — filter for augmenting the requested Google OAuth scopes.
+- `ap.icons.registerIconSets` — filter for registering additional icon sets.
+
+If you rename a hook you have already shipped, register the old name as an alias so existing subscribers keep firing:
+
+```php
+deprecateHook('order.placed', 'order.created');
+```
+
+After that call:
+
+- `addAction('order.placed', $fn)` transparently attaches to `order.created`.
+- `doAction('order.placed')` fires every callback bound to either name.
+- Any callback registered under `order.placed` **before** the `deprecateHook` call still fires when `order.created` is dispatched (belt-and-suspenders migration).
+- A callback registered under **both** names (before *and* after the rename) fires **once**, not twice — the dispatcher deduplicates across canonical + alias buckets by identity. Deliberately double-registering under the *same* name still fires twice (pre-1.3 behavior).
+- Insertion order within a priority is preserved regardless of which bucket a callback lives in.
+- The first time each unique alias is resolved this **request** (not process — see Octane note below), a deprecation notice is logged. Registrations (`add`/`remove`) never log; only dispatch (`do`/`apply`) does, so the notice is anchored to real hook use.
+- Cycles are rejected: `deprecateHook('a', 'b')` followed by `deprecateHook('b', 'a')` throws `InvalidArgumentException`.
+
+Configure the log level in `config/artisanpack/hooks.php` (publish with `php artisan vendor:publish --tag=hooks-config`) via the `deprecation_level` key, or set `HOOKS_DEPRECATION_LEVEL` in `.env`:
+
+| Value                                             | Behavior                                 |
+|---------------------------------------------------|------------------------------------------|
+| any PSR-3 level (`emergency`…`debug`; default `info`) | log at that level                    |
+| `off`                                             | suppress the deprecation log             |
+
+**Octane / queue workers.** The "log once per unique alias" dedup is scoped per request. The service provider clears it on Octane `RequestReceived` and Queue `JobProcessing` events so long-lived workers do not swallow every notice after the first request/job.
+
+`HookDeprecations` is container-resolvable via `app(HookDeprecations::class)` if you need direct access to `alias()`, `resolve()`, `resolveSilent()`, `aliasesFor()`, `hasAliases()`, or `resetLogState()`; there is intentionally no dedicated Facade.
 
 ## Testing locally
 This repository uses Pest. Run the test suite with:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
   "type": "library",
   "license": "MIT",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\Hooks\\": "src/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2c12c7a733a9c0606e08fa9a9b21953",
+    "content-hash": "40099c2e8f3aab0269d5be6d97ba566b",
     "packages": [
         {
             "name": "brick/math",

--- a/config/hooks.php
+++ b/config/hooks.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Hooks package configuration.
+ *
+ * Reading env values through this config file (rather than getenv() at call
+ * time) means the deprecation log level survives `php artisan config:cache`
+ * and works on the modern Laravel default of Env::disablePutenv().
+ *
+ * @since 1.3.0
+ */
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Deprecation Log Level
+    |--------------------------------------------------------------------------
+    |
+    | Level at which alias resolutions are logged the first time each unique
+    | old-name is seen. Accepts any PSR-3 level ("emergency", "alert",
+    | "critical", "error", "warning", "notice", "info", "debug") or "off" to
+    | suppress the log entirely.
+    |
+    */
+
+    'deprecation_level' => env('HOOKS_DEPRECATION_LEVEL', 'info'),
+
+];

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -11,6 +11,7 @@ See also: [[Filters]] and [[Priorities and Execution Order]].
 - doAction(string $hook, mixed ...$args): void
 - removeAction(string $hook, callable $callback, int $priority = 10): bool  (since 1.1.0)
 - removeAllActions(string $hook, int|false $priority = false): bool  (since 1.1.0)
+- deprecateHook(string $old, string $new): void  (since 1.3.0) — see [[Hook Naming and Deprecations]]
 
 ## Usage
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,65 @@
+---
+title: Hook Naming and Deprecations
+---
+
+Since 1.3.0, ArtisanPack UI Hooks ships a `HookDeprecations` primitive and a `deprecateHook()` helper for renaming a hook you have already shipped without breaking existing subscribers.
+
+See also: [[Actions]], [[Filters]], and [[Facades]].
+
+## Naming convention
+
+Hook names should be namespaced with dot notation and lower camelCase segments — for example, `order.placed`, `user.registered`, `ap.icons.registerIconSets`.
+
+The `ap.<domain>.<event>` prefix is reserved for cross-package hooks that any ArtisanPack UI package (or downstream app) may listen to. Two of these are intentionally shared today:
+
+- `ap.google.scopes` — filter for augmenting the requested Google OAuth scopes.
+- `ap.icons.registerIconSets` — filter for registering additional icon sets.
+
+## Renaming a hook
+
+If you rename a hook, register the old name as an alias so existing subscribers keep firing:
+
+```php
+use function deprecateHook;
+
+deprecateHook('order.placed', 'order.created');
+```
+
+After that call:
+
+- `addAction('order.placed', $fn)` transparently attaches to `order.created`.
+- `doAction('order.placed')` fires every callback bound to either name.
+- Any callback registered under `order.placed` **before** the `deprecateHook` call still fires when `order.created` is dispatched.
+- A callback registered under **both** names (before *and* after the rename) fires **once**, not twice — the dispatcher deduplicates across canonical + alias buckets by identity. Deliberately double-registering under the *same* name still fires twice (pre-1.3 behavior).
+- Insertion order within a priority is preserved regardless of which bucket a callback lives in.
+- Cycles are rejected: `deprecateHook('a', 'b')` followed by `deprecateHook('b', 'a')` throws `InvalidArgumentException`.
+
+Both `Action` and `Filter` route `add()`/`remove()`/`removeAll()` through the alias map, so the same rules apply to filters.
+
+## Deprecation logging
+
+The first time each unique alias is resolved during a request, a deprecation notice is logged. Registrations (`add`/`remove`) never log; only dispatch (`do`/`apply`) does, so the notice is anchored to real hook use, not to boot-time registration.
+
+Configure the log level by publishing the config file:
+
+```bash
+php artisan vendor:publish --tag=hooks-config
+```
+
+Then set `deprecation_level` in `config/artisanpack/hooks.php`, or set `HOOKS_DEPRECATION_LEVEL` in `.env`:
+
+| Value                                                 | Behavior                     |
+|-------------------------------------------------------|------------------------------|
+| any PSR-3 level (`emergency`…`debug`; default `info`) | log at that level            |
+| `off`                                                 | suppress the deprecation log |
+
+## Octane and queue workers
+
+The "log once per unique alias" dedup is scoped per request, not per process. The service provider clears it on Octane `RequestReceived` and Queue `JobProcessing` events so long-lived workers do not swallow every notice after the first request/job.
+
+## Direct access
+
+`HookDeprecations` is container-resolvable via `app(HookDeprecations::class)` if you need direct access to `alias()`, `resolve()`, `resolveSilent()`, `aliasesFor()`, `hasAliases()`, or `resetLogState()`. There is intentionally no dedicated Facade — `deprecateHook()` is the whole public surface.
+
+---
+Return to [[Home]].

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -11,6 +11,7 @@ See also: [[Actions]] and [[Priorities and Execution Order]].
 - applyFilters(string $hook, mixed $value, mixed ...$args): mixed
 - removeFilter(string $hook, callable $callback, int $priority = 10): bool  (since 1.1.0)
 - removeAllFilters(string $hook, int|false $priority = false): bool  (since 1.1.0)
+- deprecateHook(string $old, string $new): void  (since 1.3.0) — see [[Hook Naming and Deprecations]]
 
 ## Usage
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -14,6 +14,7 @@ Use the navigation below to explore topics. Links use the GitLab wiki page style
 - [[Priorities and Execution Order]]
 - [[Facades]]
 - [[Blade Directives]]
+- [[Hook Naming and Deprecations]]
 - [[Testing]]
 - [[FAQ]]
 - [[Security]]

--- a/src/Action.php
+++ b/src/Action.php
@@ -12,15 +12,22 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\Hooks;
 
+use ArtisanPackUI\Hooks\Concerns\ManagesHookBuckets;
 use Illuminate\Contracts\Container\Container;
 
 /**
  * Manages the registration and execution of action hooks.
  *
+ * Storage, alias resolution, add/remove/removeAll and the dedup-across-
+ * buckets logic live in {@see ManagesHookBuckets} so Action and Filter
+ * cannot drift on shared bookkeeping.
+ *
  * @since 1.0.0
  */
 class Action
 {
+    use ManagesHookBuckets;
+
     /**
      * The application container instance.
      *
@@ -29,36 +36,17 @@ class Action
     protected Container $app;
 
     /**
-     * Registered action hooks.
-     *
-     * @since 1.0.0
-     */
-    protected array $actions = [];
-
-    /**
      * Constructor.
      *
      * @since 1.0.0
      *
      * @param  Container  $app  The application container.
+     * @param  HookDeprecations|null  $deprecations  Optional deprecations manager.
      */
-    public function __construct(Container $app)
+    public function __construct(Container $app, ?HookDeprecations $deprecations = null)
     {
-        $this->app = $app;
-    }
-
-    /**
-     * Adds a callback to a specific action hook.
-     *
-     * @since 1.0.0
-     *
-     * @param  string  $hook  The name of the action.
-     * @param  callable  $callback  The callback to be executed.
-     * @param  int  $priority  Optional. The priority of the callback. Default 10.
-     */
-    public function add(string $hook, callable $callback, int $priority = 10): void
-    {
-        $this->actions[$hook][$priority][] = $callback;
+        $this->app          = $app;
+        $this->deprecations = $deprecations;
     }
 
     /**
@@ -71,86 +59,8 @@ class Action
      */
     public function do(string $hook, mixed ...$args): void
     {
-        if (! isset($this->actions[$hook])) {
-            return;
-        }
-
-        ksort($this->actions[$hook]);
-        $callbacks = array_merge(...$this->actions[$hook]);
-
-        foreach ($callbacks as $callback) {
+        foreach ($this->collectForDispatch($hook) as $callback) {
             $callback(...$args);
         }
-    }
-
-    /**
-     * Removes a specific callback from an action hook.
-     *
-     * Note: The callback must be the exact same reference (===) that was registered.
-     * Anonymous functions or recreated callables will not match even if functionally identical.
-     *
-     * @since 1.1.0
-     *
-     * @param  string  $hook  The name of the action.
-     * @param  callable  $callback  The specific callback to remove.
-     * @param  int  $priority  Optional. The priority of the callback. Default 10.
-     *
-     * @return bool True on success, false on failure.
-     */
-    public function remove(string $hook, callable $callback, int $priority = 10): bool
-    {
-        if (! isset($this->actions[$hook][$priority])) {
-            return false;
-        }
-
-        foreach ($this->actions[$hook][$priority] as $key => $registeredCallback) {
-            if ($registeredCallback === $callback) {
-                unset($this->actions[$hook][$priority][$key]);
-
-                // If the priority level is now empty, remove it to keep the array clean.
-                if (empty($this->actions[$hook][$priority])) {
-                    unset($this->actions[$hook][$priority]);
-                }
-
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Removes all callbacks for a specific action hook or a specific priority.
-     *
-     * @since 1.1.0
-     *
-     * @param  string  $hook  The name of the action.
-     * @param  false|int  $priority  Optional. A specific priority to remove. If false, all priorities are removed. Default false.
-     *
-     * @return bool True if callbacks were removed, false otherwise.
-     */
-    public function removeAll(string $hook, int|false $priority = false): bool
-    {
-        if (! isset($this->actions[$hook])) {
-            return false;
-        }
-
-        // A specific priority is requested.
-        if (false !== $priority) {
-            // Only return true if the priority level actually exists and is removed.
-            if (isset($this->actions[$hook][$priority])) {
-                unset($this->actions[$hook][$priority]);
-
-                return true;
-            }
-
-            // If the priority doesn't exist, nothing was changed, so return false.
-            return false;
-        }
-
-        // If no priority is specified, remove the entire hook.
-        unset($this->actions[$hook]);
-
-        return true;
     }
 }

--- a/src/Concerns/ManagesHookBuckets.php
+++ b/src/Concerns/ManagesHookBuckets.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Shared bucket management for hook registries.
+ *
+ * Owns the callback storage, insertion-sequence counter, add/remove/removeAll
+ * semantics, and alias resolution. Action and Filter compose this trait and
+ * only implement their dispatch primitive (do / apply) on top.
+ *
+ * @since 1.3.0
+ */
+
+namespace ArtisanPackUI\Hooks\Concerns;
+
+use ArtisanPackUI\Hooks\HookDeprecations;
+use Closure;
+
+/**
+ * @internal
+ */
+trait ManagesHookBuckets
+{
+    /**
+     * Registered callbacks keyed as [hook][priority][ [seq, callable], ... ].
+     *
+     * The seq tuple is a monotonic insertion counter that guarantees stable
+     * FIFO ordering within a priority even after alias fan-out.
+     *
+     * @since 1.3.0
+     */
+    protected array $callbacks = [];
+
+    /**
+     * Monotonic insertion counter across all hooks / priorities.
+     *
+     * @since 1.3.0
+     */
+    protected int $sequence = 0;
+
+    /**
+     * The hook deprecations manager.
+     *
+     * @since 1.3.0
+     */
+    protected ?HookDeprecations $deprecations;
+
+    /**
+     * Register a callback for a hook.
+     *
+     * Deprecated hook names are transparently routed to their canonical
+     * bucket. Registrations do NOT emit a deprecation log — that is
+     * reserved for dispatch so notices are traceable to real hook use.
+     *
+     * @since 1.0.0
+     */
+    public function add(string $hook, callable $callback, int $priority = 10): void
+    {
+        $canonical                                = $this->resolveSilent($hook);
+        $this->callbacks[$canonical][$priority][] = [$this->sequence++, $callback];
+    }
+
+    /**
+     * Remove a specific callback registration.
+     *
+     * Returns true after removing the first match; further matches (in the
+     * same bucket, in an alias bucket, or at a higher priority) are left
+     * intact — preserving the pre-1.3 "remove one exact registration"
+     * contract.
+     *
+     * @since 1.1.0
+     */
+    public function remove(string $hook, callable $callback, int $priority = 10): bool
+    {
+        $canonical = $this->resolveSilent($hook);
+
+        foreach ($this->bucketNamesFor($canonical) as $bucket) {
+            if (! isset($this->callbacks[$bucket][$priority])) {
+                continue;
+            }
+
+            foreach ($this->callbacks[$bucket][$priority] as $key => $entry) {
+                if ($entry[1] === $callback) {
+                    unset($this->callbacks[$bucket][$priority][$key]);
+                    $this->pruneBucket($bucket, $priority);
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove every callback for a hook, or every callback at a specific
+     * priority. Cascades into alias buckets so the migration guarantee
+     * ("remove works with either name") is symmetrical with add().
+     *
+     * @since 1.1.0
+     */
+    public function removeAll(string $hook, int|false $priority = false): bool
+    {
+        $canonical = $this->resolveSilent($hook);
+        $removed   = false;
+
+        foreach ($this->bucketNamesFor($canonical) as $bucket) {
+            if (! isset($this->callbacks[$bucket])) {
+                continue;
+            }
+
+            if (false !== $priority) {
+                if (isset($this->callbacks[$bucket][$priority])) {
+                    unset($this->callbacks[$bucket][$priority]);
+                    $removed = true;
+                    $this->pruneBucket($bucket);
+                }
+
+                continue;
+            }
+
+            unset($this->callbacks[$bucket]);
+            $removed = true;
+        }
+
+        return $removed;
+    }
+
+    /**
+     * Collect the callback list for a dispatch, in priority + insertion
+     * order, deduplicated across alias buckets.
+     *
+     * The fast path (no aliases in the whole app, or none for this hook)
+     * skips both the reverse-lookup and the dedup pass so the common case
+     * pays only for a single isset() branch beyond the pre-1.3 cost.
+     *
+     * @since 1.3.0
+     *
+     * @return array<int, callable>
+     */
+    protected function collectForDispatch(string $hook): array
+    {
+        $canonical = null === $this->deprecations
+            ? $hook
+            : $this->deprecations->resolve($hook);
+
+        // Fast path: no aliases in play — behave exactly like pre-1.3 storage
+        // (one bucket, sort priorities, flatten, drop the seq tuple).
+        $aliases = null === $this->deprecations || ! $this->deprecations->hasAliases()
+            ? []
+            : $this->deprecations->aliasesFor($canonical);
+
+        if (empty($aliases)) {
+            if (! isset($this->callbacks[$canonical])) {
+                return [];
+            }
+
+            $bucket = $this->callbacks[$canonical];
+            ksort($bucket);
+
+            $out = [];
+            foreach ($bucket as $entries) {
+                foreach ($entries as $entry) {
+                    $out[] = $entry[1];
+                }
+            }
+
+            return $out;
+        }
+
+        // Alias fan-out: collect entries across canonical + every alias, sort
+        // by (priority, insertion-seq) for stable FIFO, and skip callables
+        // already contributed by an earlier bucket (cross-bucket dedup).
+        $entries = [];
+        foreach (array_merge([$canonical], $aliases) as $bucket) {
+            if (! isset($this->callbacks[$bucket])) {
+                continue;
+            }
+
+            foreach ($this->callbacks[$bucket] as $priority => $list) {
+                foreach ($list as [$seq, $cb]) {
+                    $entries[] = [$priority, $seq, $cb, $bucket];
+                }
+            }
+        }
+
+        if (empty($entries)) {
+            return [];
+        }
+
+        usort($entries, static fn (array $a, array $b): int => $a[0] <=> $b[0] ?: $a[1] <=> $b[1]);
+
+        $seenBuckets = [];
+        $seenKeys    = [];
+        $out         = [];
+
+        foreach ($entries as [$priority, $seq, $cb, $bucket]) {
+            $key = $this->callableKey($cb);
+
+            // Within one bucket, allow duplicate registrations (someone who
+            // explicitly did add() twice expects two fires). Across buckets,
+            // skip the callable if a prior bucket already contributed it.
+            if (isset($seenKeys[$key]) && ! isset($seenBuckets[$bucket][$key])) {
+                continue;
+            }
+
+            $seenKeys[$key]             = true;
+            $seenBuckets[$bucket][$key] = true;
+            $out[]                      = $cb;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Resolve a hook name without emitting a log entry.
+     *
+     * Used by add/remove/removeAll so registration bookkeeping does not
+     * burn the "log once per unique alias" budget before any real dispatch
+     * has happened — that would strip stack context and make the notice
+     * untraceable to the code that fires the hook.
+     *
+     * @since 1.3.0
+     */
+    protected function resolveSilent(string $hook): string
+    {
+        return null === $this->deprecations
+            ? $hook
+            : $this->deprecations->resolveSilent($hook);
+    }
+
+    /**
+     * Canonical + every alias pointing at it, for fan-out during remove/removeAll.
+     *
+     * @since 1.3.0
+     *
+     * @return array<int, string>
+     */
+    protected function bucketNamesFor(string $canonical): array
+    {
+        if (null === $this->deprecations || ! $this->deprecations->hasAliases()) {
+            return [$canonical];
+        }
+
+        return array_merge([$canonical], $this->deprecations->aliasesFor($canonical));
+    }
+
+    /**
+     * Compute a stable key for a callable so cross-bucket duplicates can be
+     * detected by identity, not by whatever string PHP would produce.
+     *
+     * Covers every shape callable syntax accepts:
+     * - string function name
+     * - Closure
+     * - invokable object
+     * - [object, methodName]
+     * - [ClassName::class, staticMethod]
+     *
+     * @since 1.3.0
+     */
+    protected function callableKey(callable $cb): string
+    {
+        if (is_string($cb)) {
+            return 'fn:'.$cb;
+        }
+
+        if ($cb instanceof Closure) {
+            return 'closure:'.spl_object_id($cb);
+        }
+
+        if (is_object($cb)) {
+            return 'invokable:'.spl_object_id($cb);
+        }
+
+        // Array form: [class-or-object, methodName].
+        [$target, $method] = $cb;
+
+        return is_object($target)
+            ? 'method:'.spl_object_id($target).'::'.$method
+            : 'static:'.$target.'::'.$method;
+    }
+
+    /**
+     * Clean up empty priority arrays (and the whole hook entry when its last
+     * priority is removed) so removeAll semantics match the pre-1.3 contract.
+     *
+     * @since 1.3.0
+     */
+    protected function pruneBucket(string $bucket, ?int $priority = null): void
+    {
+        if (null !== $priority && empty($this->callbacks[$bucket][$priority])) {
+            unset($this->callbacks[$bucket][$priority]);
+        }
+
+        if (empty($this->callbacks[$bucket])) {
+            unset($this->callbacks[$bucket]);
+        }
+    }
+}

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -11,15 +11,21 @@ declare(strict_types=1);
 
 namespace ArtisanPackUI\Hooks;
 
+use ArtisanPackUI\Hooks\Concerns\ManagesHookBuckets;
 use Illuminate\Contracts\Container\Container;
 
 /**
  * Manages the registration and execution of filter hooks.
  *
+ * Storage, alias resolution, add/remove/removeAll and the dedup-across-
+ * buckets logic live in {@see ManagesHookBuckets}.
+ *
  * @since 1.0.0
  */
 class Filter
 {
+    use ManagesHookBuckets;
+
     /**
      * The application container instance.
      *
@@ -28,36 +34,17 @@ class Filter
     protected Container $app;
 
     /**
-     * Registered filter hooks.
-     *
-     * @since 1.0.0
-     */
-    protected array $filters = [];
-
-    /**
      * Constructor.
      *
      * @since 1.0.0
      *
      * @param  Container  $app  The application container.
+     * @param  HookDeprecations|null  $deprecations  Optional deprecations manager.
      */
-    public function __construct(Container $app)
+    public function __construct(Container $app, ?HookDeprecations $deprecations = null)
     {
-        $this->app = $app;
-    }
-
-    /**
-     * Adds a callback to a specific filter hook.
-     *
-     * @since 1.0.0
-     *
-     * @param  string  $hook  The name of the filter.
-     * @param  callable  $callback  The callback to be executed.
-     * @param  int  $priority  Optional. The priority of the callback. Default 10.
-     */
-    public function add(string $hook, callable $callback, int $priority = 10): void
-    {
-        $this->filters[$hook][$priority][] = $callback;
+        $this->app          = $app;
+        $this->deprecations = $deprecations;
     }
 
     /**
@@ -73,92 +60,19 @@ class Filter
      */
     public function apply(string $hook, mixed $value, mixed ...$args): mixed
     {
-        if (! isset($this->filters[$hook])) {
+        $callbacks = $this->collectForDispatch($hook);
+
+        if (empty($callbacks)) {
             return $value;
         }
-
-        ksort($this->filters[$hook]);
-        $callbacks = array_merge(...$this->filters[$hook]);
 
         $allArgs = array_merge([$value], $args);
 
         foreach ($callbacks as $callback) {
-            // Use the splat operator for the call.
-            $value = $callback(...$allArgs);
-            // Update the value for the next callback in the chain.
+            $value      = $callback(...$allArgs);
             $allArgs[0] = $value;
         }
 
         return $value;
-    }
-
-    /**
-     * Removes a specific callback from a filter hook.
-     *
-     * Note: The callback must be the exact same reference (===) that was registered.
-     * Anonymous functions or recreated callables will not match even if functionally identical.
-     *
-     * @since 1.1.0
-     *
-     * @param  string  $hook  The name of the filter.
-     * @param  callable  $callback  The specific callback to remove.
-     * @param  int  $priority  Optional. The priority of the callback. Default 10.
-     *
-     * @return bool True on success, false on failure.
-     */
-    public function remove(string $hook, callable $callback, int $priority = 10): bool
-    {
-        if (! isset($this->filters[$hook][$priority])) {
-            return false;
-        }
-
-        foreach ($this->filters[$hook][$priority] as $key => $registeredCallback) {
-            if ($registeredCallback === $callback) {
-                unset($this->filters[$hook][$priority][$key]);
-
-                if (empty($this->filters[$hook][$priority])) {
-                    unset($this->filters[$hook][$priority]);
-                }
-
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Removes all callbacks for a specific filter hook or a specific priority.
-     *
-     * @since 1.1.0
-     *
-     * @param  string  $hook  The name of the filter.
-     * @param  false|int  $priority  Optional. A specific priority to remove. If false, all priorities are removed. Default false.
-     *
-     * @return bool True if callbacks were removed, false otherwise.
-     */
-    public function removeAll(string $hook, int|false $priority = false): bool
-    {
-        if (! isset($this->filters[$hook])) {
-            return false;
-        }
-
-        // A specific priority is requested.
-        if (false !== $priority) {
-            // Only return true if the priority level actually exists and is removed.
-            if (isset($this->filters[$hook][$priority])) {
-                unset($this->filters[$hook][$priority]);
-
-                return true;
-            }
-
-            // If the priority doesn't exist, nothing was changed, so return false.
-            return false;
-        }
-
-        // If no priority is specified, remove the entire hook.
-        unset($this->filters[$hook]);
-
-        return true;
     }
 }

--- a/src/HookDeprecations.php
+++ b/src/HookDeprecations.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Hook Deprecations Manager
+ *
+ * Tracks aliases between old and canonical hook names so that renames
+ * can ship without silently breaking existing subscribers.
+ *
+ * @since      1.3.0
+ */
+
+namespace ArtisanPackUI\Hooks;
+
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+
+/**
+ * Registers aliases from old hook names to canonical ones and logs each
+ * resolution at most once per unique alias per request.
+ *
+ * @since 1.3.0
+ */
+class HookDeprecations
+{
+    /**
+     * Map of old hook name to canonical hook name.
+     *
+     * @since 1.3.0
+     *
+     * @var array<string, string>
+     */
+    protected array $aliases = [];
+
+    /**
+     * Reverse index of canonical hook name to its old-name aliases.
+     *
+     * Maintained in alias() so aliasesFor() is O(1) instead of O(N) per
+     * call — aliasesFor() runs on every hook dispatch, alias() is write-rare.
+     *
+     * @since 1.3.0
+     *
+     * @var array<string, array<int, string>>
+     */
+    protected array $reverseIndex = [];
+
+    /**
+     * Set of old hook names that have already been logged this request.
+     *
+     * Cleared by resetLogState() on Octane RequestReceived and Queue
+     * Looping/JobProcessing events so operators see the notice on every
+     * request/job boundary rather than only once at worker boot.
+     *
+     * @since 1.3.0
+     *
+     * @var array<string, true>
+     */
+    protected array $logged = [];
+
+    /**
+     * Register a rename from an old hook name to a canonical one.
+     *
+     * Chains are collapsed so that resolving an alias always returns the
+     * ultimate canonical name in a single lookup. Cycles (a rename whose
+     * canonical would transitively point back at the old name) are rejected
+     * — silently accepting them produces self-aliases that log nonsensical
+     * "Hook X deprecated; use X instead" notices forever.
+     *
+     * @since 1.3.0
+     *
+     * @throws InvalidArgumentException When the rename would create a cycle.
+     */
+    public function alias(string $old, string $new): void
+    {
+        if ($old === $new) {
+            return;
+        }
+
+        // Collapse chains so aliases[$old] points at the ultimate canonical
+        // in one hop. If $new already resolves to $old, that's a cycle.
+        $canonical = $this->aliases[$new] ?? $new;
+
+        if ($canonical === $old) {
+            throw new InvalidArgumentException(
+                "Refusing to alias hook \"{$old}\" to \"{$new}\": would create a cycle "
+                ."(\"{$new}\" already resolves to \"{$old}\").",
+            );
+        }
+
+        // If the old name was already the target of some earlier alias, walk
+        // those pointers forward to the new canonical.
+        if (isset($this->reverseIndex[$old])) {
+            foreach ($this->reverseIndex[$old] as $priorOld) {
+                $this->aliases[$priorOld]         = $canonical;
+                $this->reverseIndex[$canonical][] = $priorOld;
+            }
+            unset($this->reverseIndex[$old]);
+        }
+
+        $this->aliases[$old]              = $canonical;
+        $this->reverseIndex[$canonical][] = $old;
+    }
+
+    /**
+     * Resolve a hook name to its canonical form and emit a deprecation
+     * notice the first time each unique alias is resolved this request.
+     *
+     * Called from dispatch paths (Action::do, Filter::apply) — routing
+     * add/remove through here would strip stack context from the log entry
+     * and exhaust the once-per-request budget before any real hook fires.
+     *
+     * @since 1.3.0
+     */
+    public function resolve(string $hook): string
+    {
+        if (! isset($this->aliases[$hook])) {
+            return $hook;
+        }
+
+        $canonical = $this->aliases[$hook];
+
+        if (! isset($this->logged[$hook])) {
+            $this->logged[$hook] = true;
+            $this->log($hook, $canonical);
+        }
+
+        return $canonical;
+    }
+
+    /**
+     * Resolve a hook name without logging. Used by add/remove/removeAll so
+     * registration bookkeeping does not consume the log-once budget.
+     *
+     * @since 1.3.0
+     */
+    public function resolveSilent(string $hook): string
+    {
+        return $this->aliases[$hook] ?? $hook;
+    }
+
+    /**
+     * Return every old-name alias that resolves to the given canonical hook.
+     *
+     * Backed by a reverse index so this is O(1) — it runs on every hook
+     * dispatch when aliases are in play.
+     *
+     * @since 1.3.0
+     *
+     * @return array<int, string>
+     */
+    public function aliasesFor(string $canonical): array
+    {
+        return $this->reverseIndex[$canonical] ?? [];
+    }
+
+    /**
+     * Whether any aliases have been registered. Consumers can short-circuit
+     * to the pre-1.3 fast path when this is false.
+     *
+     * @since 1.3.0
+     */
+    public function hasAliases(): bool
+    {
+        return ! empty($this->aliases);
+    }
+
+    /**
+     * Clear the "seen this alias" set so the deprecation notice fires again
+     * on the next resolution.
+     *
+     * Bound to Octane RequestReceived and Queue Looping events by the
+     * service provider so long-lived workers do not swallow every notice
+     * after the first request/job.
+     *
+     * @since 1.3.0
+     */
+    public function resetLogState(): void
+    {
+        $this->logged = [];
+    }
+
+    /**
+     * Emit a deprecation log at the configured level.
+     *
+     * Reads config('artisanpack.hooks.deprecation_level') so the value
+     * survives config:cache and works on the modern Laravel default of
+     * Env::disablePutenv(). Falls back to $_ENV / getenv() (in that order)
+     * when the Laravel config helper is unavailable — keeps the primitive
+     * usable outside a booted framework, e.g. in standalone Orchestra
+     * Testbench tests.
+     *
+     * Any unknown value falls back to "info"; "off" suppresses the log.
+     *
+     * @since 1.3.0
+     */
+    protected function log(string $old, string $canonical): void
+    {
+        $level = strtolower((string) $this->configuredLevel());
+
+        if ('off' === $level) {
+            return;
+        }
+
+        // PSR-3 levels — accept the full set so operators can escalate a
+        // deprecation to "error" (say, in CI) without the primitive
+        // silently downgrading them.
+        $psrLevels = ['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'];
+
+        if (! in_array($level, $psrLevels, true)) {
+            $level = 'info';
+        }
+
+        Log::log(
+            $level,
+            "Hook \"{$old}\" is deprecated; use \"{$canonical}\" instead.",
+            ['old' => $old, 'canonical' => $canonical],
+        );
+    }
+
+    /**
+     * Read the configured deprecation level, preferring Laravel's config
+     * repository and falling back to raw env access.
+     *
+     * @since 1.3.0
+     */
+    protected function configuredLevel(): string
+    {
+        if (function_exists('config')) {
+            $fromConfig = config('artisanpack.hooks.deprecation_level');
+
+            if (null !== $fromConfig && '' !== $fromConfig) {
+                return (string) $fromConfig;
+            }
+        }
+
+        $fromEnv = $_ENV['HOOKS_DEPRECATION_LEVEL']
+            ?? $_SERVER['HOOKS_DEPRECATION_LEVEL']
+            ?? getenv('HOOKS_DEPRECATION_LEVEL');
+
+        return false === $fromEnv || null === $fromEnv || '' === $fromEnv
+            ? 'info'
+            : (string) $fromEnv;
+    }
+}

--- a/src/Providers/HooksServiceProvider.php
+++ b/src/Providers/HooksServiceProvider.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 /**
  * Hooks Service Provider
  *
- * Registers the Action and Filter singletons for the Hooks package.
+ * Registers the Action, Filter, and HookDeprecations singletons and wires
+ * the deprecation-log reset into Octane / queue lifecycle events.
  *
  * @since      1.0.0
  */
@@ -13,6 +14,8 @@ namespace ArtisanPackUI\Hooks\Providers;
 
 use ArtisanPackUI\Hooks\Action;
 use ArtisanPackUI\Hooks\Filter;
+use ArtisanPackUI\Hooks\HookDeprecations;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -25,20 +28,73 @@ class HooksServiceProvider extends ServiceProvider
     /**
      * Register any application services.
      *
-     * Binds the Action and Filter managers into the container as singletons.
-     *
      * @since 1.0.0
      */
     public function register(): void
     {
+        $this->mergeConfigFrom(__DIR__.'/../../config/hooks.php', 'artisanpack.hooks');
+
+        // Register HookDeprecations as a singleton so alias state is
+        // shared across every Action/Filter resolution.
+        $this->app->singleton(HookDeprecations::class, function () {
+            return new HookDeprecations;
+        });
+
         // Register Action as a singleton.
         $this->app->singleton(Action::class, function ($app) {
-            return new Action($app);
+            return new Action($app, $app->make(HookDeprecations::class));
         });
 
         // Register Filter as a singleton.
         $this->app->singleton(Filter::class, function ($app) {
-            return new Filter($app);
+            return new Filter($app, $app->make(HookDeprecations::class));
         });
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @since 1.0.0
+     */
+    public function boot(): void
+    {
+        $this->publishes([
+            __DIR__.'/../../config/hooks.php' => $this->app->configPath('artisanpack/hooks.php'),
+        ], 'hooks-config');
+
+        $this->registerLogResetListeners();
+    }
+
+    /**
+     * Reset the deprecation log-once budget on every request/job boundary.
+     *
+     * Without this, HookDeprecations::$logged would accumulate across an
+     * Octane worker's lifetime and a deprecated hook fired thousands of
+     * times a second would log exactly once at worker boot — operators
+     * would then miss it and assume the migration is complete.
+     *
+     * Uses string event names so the package does not have to depend on
+     * either laravel/octane or laravel/queue being installed; the
+     * dispatcher simply never fires them when the classes are absent.
+     *
+     * @since 1.3.0
+     */
+    protected function registerLogResetListeners(): void
+    {
+        if (! $this->app->bound(Dispatcher::class)) {
+            return;
+        }
+
+        $events = $this->app->make(Dispatcher::class);
+
+        $reset = function (): void {
+            $this->app->make(HookDeprecations::class)->resetLogState();
+        };
+
+        // Octane: reset before each request the worker serves.
+        $events->listen('Laravel\\Octane\\Events\\RequestReceived', $reset);
+
+        // Queue worker: reset before each job the worker picks up.
+        $events->listen('Illuminate\\Queue\\Events\\JobProcessing', $reset);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 use ArtisanPackUI\Hooks\Facades\Action;
 use ArtisanPackUI\Hooks\Facades\Filter;
+use ArtisanPackUI\Hooks\HookDeprecations;
 
 if (! function_exists('addAction')) {
     /**
@@ -161,5 +162,27 @@ if (! function_exists('removeAllFilters')) {
     function removeAllFilters(string $hook, int|false $priority = false): bool
     {
         return Filter::removeAll($hook, $priority);
+    }
+}
+
+if (! function_exists('deprecateHook')) {
+    /**
+     * Register a hook rename so old-name subscribers continue to fire on
+     * the canonical hook.
+     *
+     * A deprecation notice is logged the first time an alias is resolved
+     * this process. Logging is env-gated via HOOKS_DEPRECATION_LEVEL
+     * (warning|info|debug|off, default info).
+     *
+     * @since 1.3.0
+     *
+     * @uses \ArtisanPackUI\Hooks\HookDeprecations::alias()
+     *
+     * @param  string  $old  The previous hook name.
+     * @param  string  $new  The canonical hook name.
+     */
+    function deprecateHook(string $old, string $new): void
+    {
+        app(HookDeprecations::class)->alias($old, $new);
     }
 }

--- a/tests/Unit/HookDeprecationsTest.php
+++ b/tests/Unit/HookDeprecationsTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Hook Deprecations Unit Tests
+ *
+ * @since      1.3.0
+ */
+
+namespace ArtisanPackUI\Hooks\Tests\Unit;
+
+use ArtisanPackUI\Hooks\Action;
+use ArtisanPackUI\Hooks\Filter;
+use ArtisanPackUI\Hooks\HookDeprecations;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+
+beforeEach(function (): void {
+    // Default env: logging on at info level. Individual tests override via config().
+    config()->set('artisanpack.hooks.deprecation_level', 'info');
+
+    $this->deprecations = $this->app->make(HookDeprecations::class);
+    $this->actions      = $this->app->make(Action::class);
+    $this->filters      = $this->app->make(Filter::class);
+});
+
+test('resolve returns the same hook name when no alias is registered', function (): void {
+    expect($this->deprecations->resolve('some.hook'))->toBe('some.hook');
+});
+
+test('resolve returns the canonical name for a registered alias', function (): void {
+    $this->deprecations->alias('old.hook', 'new.hook');
+
+    expect($this->deprecations->resolve('old.hook'))->toBe('new.hook');
+});
+
+test('resolveSilent does not emit a log entry', function (): void {
+    Log::spy();
+
+    $this->deprecations->alias('old.silent', 'new.silent');
+    $this->deprecations->resolveSilent('old.silent');
+
+    Log::shouldNotHaveReceived('log');
+});
+
+test('aliasesFor returns every old name pointing at a canonical', function (): void {
+    $this->deprecations->alias('a', 'canonical');
+    $this->deprecations->alias('b', 'canonical');
+    $this->deprecations->alias('c', 'other');
+
+    $aliases = $this->deprecations->aliasesFor('canonical');
+    sort($aliases);
+
+    expect($aliases)->toBe(['a', 'b']);
+});
+
+test('alias chains collapse to the final canonical', function (): void {
+    $this->deprecations->alias('old', 'middle');
+    $this->deprecations->alias('middle', 'newest');
+
+    expect($this->deprecations->resolve('old'))->toBe('newest');
+    expect($this->deprecations->resolve('middle'))->toBe('newest');
+    expect($this->deprecations->aliasesFor('newest'))->toContain('old', 'middle');
+});
+
+test('alias rejects cycles instead of creating self-aliases', function (): void {
+    $this->deprecations->alias('a', 'b');
+
+    expect(fn () => $this->deprecations->alias('b', 'a'))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('hasAliases reflects registration state', function (): void {
+    expect($this->deprecations->hasAliases())->toBeFalse();
+    $this->deprecations->alias('old', 'new');
+    expect($this->deprecations->hasAliases())->toBeTrue();
+});
+
+test('old-name addAction fires when canonical doAction fires', function (): void {
+    $this->deprecations->alias('order.placed', 'order.created');
+
+    $fired = false;
+    $this->actions->add('order.placed', function () use (&$fired): void {
+        $fired = true;
+    });
+
+    $this->actions->do('order.created');
+
+    expect($fired)->toBeTrue();
+});
+
+test('canonical-name addAction fires when old-name doAction fires', function (): void {
+    $this->deprecations->alias('order.placed', 'order.created');
+
+    $fired = false;
+    $this->actions->add('order.created', function () use (&$fired): void {
+        $fired = true;
+    });
+
+    $this->actions->do('order.placed');
+
+    expect($fired)->toBeTrue();
+});
+
+test('callbacks registered before deprecation still fire via belt-and-suspenders fan-out', function (): void {
+    $fired = false;
+    // Subscriber registered under the old name before the rename shipped.
+    $this->actions->add('legacy.name', function () use (&$fired): void {
+        $fired = true;
+    });
+
+    $this->deprecations->alias('legacy.name', 'modern.name');
+
+    $this->actions->do('modern.name');
+
+    expect($fired)->toBeTrue();
+});
+
+test('same callback registered under both names fires only once per dispatch', function (): void {
+    $count = 0;
+    $cb    = function () use (&$count): void {
+        $count++;
+    };
+
+    // Registered under old name before the alias exists.
+    $this->actions->add('shared.legacy', $cb);
+    $this->deprecations->alias('shared.legacy', 'shared.canonical');
+    // Then also registered under the canonical name.
+    $this->actions->add('shared.canonical', $cb);
+
+    $this->actions->do('shared.canonical');
+
+    expect($count)->toBe(1);
+});
+
+test('deliberately double-adding a callback in the same bucket still fires it twice', function (): void {
+    // Ensure the cross-bucket dedup does not accidentally dedupe within a
+    // single bucket — pre-1.3 double-adds must still fire twice.
+    $count = 0;
+    $cb    = function () use (&$count): void {
+        $count++;
+    };
+
+    $this->actions->add('same.bucket', $cb);
+    $this->actions->add('same.bucket', $cb);
+
+    $this->actions->do('same.bucket');
+
+    expect($count)->toBe(2);
+});
+
+test('filters resolve aliases and fold callbacks in strict insertion order within a priority', function (): void {
+    // Callbacks at the same priority fire in registration order regardless
+    // of which bucket (canonical or alias) they belong to.
+    $this->filters->add('old.filter', fn (string $v) => $v.':A', 10); // t=0, bucket=old
+    $this->deprecations->alias('old.filter', 'new.filter');
+    $this->filters->add('new.filter', fn (string $v) => $v.':B', 10); // t=1, bucket=canonical
+    $this->filters->add('old.filter', fn (string $v) => $v.':C', 10); // t=2, bucket=canonical (post-alias route)
+
+    expect($this->filters->apply('new.filter', 'seed'))->toBe('seed:A:B:C');
+});
+
+test('filters honor priority across canonical + alias buckets', function (): void {
+    $this->filters->add('old.filter', fn (string $v) => $v.':pre-old', 5);
+    $this->deprecations->alias('old.filter', 'new.filter');
+    $this->filters->add('new.filter', fn (string $v) => $v.':canonical', 10);
+    $this->filters->add('old.filter', fn (string $v) => $v.':post-old', 20);
+
+    expect($this->filters->apply('new.filter', 'seed'))->toBe('seed:pre-old:canonical:post-old');
+});
+
+test('add and remove do not log deprecations — only dispatch does', function (): void {
+    Log::spy();
+
+    $this->deprecations->alias('quiet.old', 'quiet.new');
+
+    $cb = function (): void {};
+    $this->actions->add('quiet.old', $cb);
+    $this->actions->remove('quiet.old', $cb);
+
+    Log::shouldNotHaveReceived('log');
+
+    // Dispatch DOES log.
+    $this->actions->do('quiet.old');
+    Log::shouldHaveReceived('log')->once();
+});
+
+test('deprecation log fires exactly once per unique alias per request', function (): void {
+    Log::spy();
+
+    $this->deprecations->alias('a.old', 'a.new');
+    $this->deprecations->alias('b.old', 'b.new');
+
+    $this->deprecations->resolve('a.old');
+    $this->deprecations->resolve('a.old');
+    $this->deprecations->resolve('a.old');
+    $this->deprecations->resolve('b.old');
+    $this->deprecations->resolve('b.old');
+
+    Log::shouldHaveReceived('log')->twice();
+});
+
+test('resetLogState re-arms the once-per-request dedup', function (): void {
+    Log::spy();
+
+    $this->deprecations->alias('reset.old', 'reset.new');
+
+    $this->deprecations->resolve('reset.old');
+    $this->deprecations->resolve('reset.old');
+    Log::shouldHaveReceived('log')->once();
+
+    $this->deprecations->resetLogState();
+
+    $this->deprecations->resolve('reset.old');
+    Log::shouldHaveReceived('log')->twice();
+});
+
+test('deprecation_level=off suppresses the deprecation log', function (): void {
+    config()->set('artisanpack.hooks.deprecation_level', 'off');
+    Log::spy();
+
+    $this->deprecations->alias('quiet.old', 'quiet.new');
+    $this->deprecations->resolve('quiet.old');
+
+    Log::shouldNotHaveReceived('log');
+});
+
+test('deprecation_level accepts any PSR-3 level', function (): void {
+    config()->set('artisanpack.hooks.deprecation_level', 'error');
+    Log::spy();
+
+    $this->deprecations->alias('escalate.old', 'escalate.new');
+    $this->deprecations->resolve('escalate.old');
+
+    Log::shouldHaveReceived('log')->once()->withArgs(function ($level): bool {
+        return 'error' === $level;
+    });
+});
+
+test('remove stops after the first matching bucket instead of clearing all copies', function (): void {
+    // Callback registered in both buckets — remove must only take one out.
+    $count = 0;
+    $cb    = function () use (&$count): void {
+        $count++;
+    };
+
+    $this->actions->add('shared.legacy', $cb);
+    $this->deprecations->alias('shared.legacy', 'shared.canonical');
+    $this->actions->add('shared.canonical', $cb);
+
+    expect($this->actions->remove('shared.canonical', $cb))->toBeTrue();
+
+    $this->actions->do('shared.canonical');
+
+    // One copy survived, so the callback fires exactly once (cross-bucket
+    // dedup does not apply because only one bucket now holds it).
+    expect($count)->toBe(1);
+});
+
+test('removeAction works when called with the old alias name', function (): void {
+    $this->deprecations->alias('old.remove', 'new.remove');
+
+    $callback = function (): void {};
+    $this->actions->add('new.remove', $callback);
+
+    expect($this->actions->remove('old.remove', $callback))->toBeTrue();
+
+    $fired = false;
+    $this->actions->add('new.remove', function () use (&$fired): void {
+        $fired = true;
+    });
+    $this->actions->do('new.remove');
+    expect($fired)->toBeTrue();
+});
+
+test('removeFilter works when called with the canonical name after registering under the old name', function (): void {
+    $callback = function (mixed $v): mixed { return $v; };
+    $this->filters->add('old.remove', $callback);
+
+    $this->deprecations->alias('old.remove', 'new.remove');
+
+    expect($this->filters->remove('new.remove', $callback))->toBeTrue();
+});
+
+test('removeAll clears both canonical and alias buckets', function (): void {
+    $this->filters->add('legacy.name', fn (mixed $v) => $v.'b');
+    $this->deprecations->alias('legacy.name', 'canonical.name');
+    $this->filters->add('legacy.name', fn (mixed $v) => $v.'a');
+
+    expect($this->filters->apply('canonical.name', 'seed'))->not->toBe('seed');
+    expect($this->filters->removeAll('canonical.name'))->toBeTrue();
+    expect($this->filters->apply('canonical.name', 'seed'))->toBe('seed');
+});
+
+test('no-alias fast path preserves pre-1.3 dispatch semantics', function (): void {
+    // With no aliases at all, dispatch should not touch the alias-fanout
+    // machinery — behavior matches the pre-1.3 flat-priority path.
+    $this->filters->add('plain.hook', fn (string $v) => strtoupper($v), 10);
+    $this->filters->add('plain.hook', fn (string $v) => "[$v]", 20);
+
+    expect($this->filters->apply('plain.hook', 'x'))->toBe('[X]');
+});


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.3.0
- **Release Date:** 2026-07-20
- **Release Type:** Minor
- **Release Branch:** `release/1.3`
- **Target Branch:** `main`

## Release Summary

Introduces `HookDeprecations` — a first-class primitive for renaming a shipped hook without breaking existing subscribers. A single `deprecateHook('order.placed', 'order.created')` call registers an alias; both `Action` and `Filter` transparently route `add`/`remove`/`removeAll` through the alias map, and `do`/`apply` fan out across canonical + alias buckets with per-callback identity de-duplication. Deprecation notices log once per unique alias per request (Octane / queue-worker aware), gated by a `deprecation_level` config key.

## Changelog

### Added
- `HookDeprecations` primitive + `deprecateHook()` helper for backwards-compatible hook renaming
- Publishable config at `config/hooks.php` (`deprecation_level` key; `HOOKS_DEPRECATION_LEVEL` env fallback)
- `src/Concerns/ManagesHookBuckets.php` trait shared by `Action` and `Filter`
- README section on hook naming conventions and shared cross-package hooks (`ap.google.scopes`, `ap.icons.registerIconSets`)
- `docs/deprecations.md` covering the new primitive, config, logging, and Octane/queue behavior

### Changed
- `Action` and `Filter` now resolve hook names through the alias map on every operation
- Insertion-order tie-break within a priority preserved via monotonic sequence counter (survives alias routing)

### Notes
- Cycles are rejected (`InvalidArgumentException`)
- Deprecation notices fire only on dispatch, never on registration
- Dedup state resets on Octane `RequestReceived` and Queue `JobProcessing`

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

## Testing Checklist

- [x] All automated tests passing (44 tests, 57 assertions)
- [ ] Manual testing completed
- [x] Security scan completed (3 medium advisories in dev-only `guzzlehttp/*` transient deps; no runtime impact)

## Documentation Checklist

- [x] CHANGELOG updated
- [x] README updated
- [x] API documentation updated (`docs/actions.md`, `docs/filters.md`, `docs/deprecations.md`, `docs/home.md`)
- [ ] Migration guide written (not needed — no breaking changes)
- [x] Release notes written

## Pre-Release Checklist

- [x] Version number updated in all necessary files (composer.json = 1.3.0; `@since 1.3.0` tags on new symbols in `config/hooks.php`, `src/HookDeprecations.php`, helper additions)
- [ ] Git tag prepared: `v1.3.0`
- [x] Release branch created/updated: `release/1.3`
- [x] Dependencies updated and tested (composer.lock synced)
- [x] Rollback plan prepared (revert merge commit; consumers pin `^1.2.1`)

## Dependency Notes

`composer audit` reports 3 medium-severity CVEs on `guzzlehttp/guzzle` and `guzzlehttp/psr7`. Both are transient dev-only dependencies pulled in via `orchestra/testbench`; neither is loaded at runtime by this package.

## Notes

Lint: `./vendor/bin/pint` — passed (no changes).
Tests: `./vendor/bin/pest` — 44 passed / 57 assertions / 0.29s.

---

**Release Manager:** @jacobmartella

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backward-compatible hook renaming through the `deprecateHook(old, new)` helper.
  * Hook aliases preserve callback priority and ordering while preventing duplicate dispatches.
  * Added configurable deprecation notices, including “off” support and request/job-scoped logging.
  * Added hook naming guidance and documentation for shared hook conventions.

* **Documentation**
  * Updated API references, navigation, README content, and release notes for version 1.3.0.
  * Added publishable hook deprecation configuration with an informational default logging level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->